### PR TITLE
Update wcslib.rb

### DIFF
--- a/wcslib.rb
+++ b/wcslib.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Wcslib < Formula
   homepage "http://www.atnf.csiro.au/people/mcalabre/WCS/"
-  url "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-4.23.tar.bz2"
+  url "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-4.24.tar.bz2"
   sha1 "6b335277b4915c76d74b222f0e63a33e49f7d857"
 
   option "with-pgsbox", "Build PGSBOX, a general curvilinear axis drawing routine for PGPLOT"


### PR DESCRIPTION
wcslib-4.23.tar.bz2 is not listed at the URL specified. Update to use 4.24 (should see if 4.25 works, as that is the most recent)